### PR TITLE
+ updating the lib version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>com.mytaxi.apis</groupId>
             <artifactId>phrase-java-client</artifactId>
-            <version>1.0.1</version>
+            <version>1.0.5</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Please update the main lib's version, as the previous version doesn't throw exceptions when a call to PhraseApp failed:
```
private void initLocales()
    {
        try
        {
            LOG.debug("Start: Initialize all locales for projectIds: " + projectIdString);
            phraseLocales = localeAPI.listLocales(projectIds);
            LOG.trace("Locales are successfully retreived: " + Joiner.on(",").join(phraseLocales));
            LOG.debug("End: Initialize all locales for projectIds: " + projectIdString);
        }
        catch (final Exception e)
        {
            LOG.error("Error due calling the locales from phrase app", e);
        }
    }
```

and the build process continues even though the phrases retrieve failed